### PR TITLE
Fixed the issue with tag migration.

### DIFF
--- a/src/service/qase.py
+++ b/src/service/qase.py
@@ -159,16 +159,25 @@ class QaseService:
             data['default_value'] = self.__get_default_value(field)
         if (field['type_id'] == 12 or field['type_id'] == 6):
             if len(field['configs']) > 0:
-                values = self.__split_values(field['configs'][0]['options']['items'])
+                values_temp = {}
+                i = 0
+                for config in field['configs']:
+                    values = self.__split_values(config['options']['items'])
+                    for key, value in values.items():
+                        if value.strip() not in values_temp:
+                            i = i + 1
+                            values_temp[value.strip()] = i
+
+
                 field['qase_values'] = {}
-                for key, value in values.items():
+                for key, value in values_temp.items():
                     data['value'].append(
                         CustomFieldCreateValueInner(
-                            id=int(key)+1, # hack as in testrail ids can start from 0
-                            title=value,
+                            id=value,  # hack as in testrail ids can start from 0
+                            title=key,
                         ),
                     )
-                    field['qase_values'][int(key)+1] = value
+                    field['qase_values'][value] = key
             else:
                 self.logger.log('Error creating custom field: ' + field['label'] + '. No options found', 'warning')
         return data
@@ -336,8 +345,8 @@ class QaseService:
                         #if (result['defects']):
                             #self.defects.append({"case_id": result["case_id"],"defects": result['defects'],"run_id": qase_run_id})
 
-                        if result['created_by']:
-                            data['author_id'] = mappings.get_user_id(result['created_by'])
+                        # if result['created_by']:
+                        #     data['author_id'] = mappings.get_user_id(result['created_by'])
 
                         if 'custom_step_results' in result and result['custom_step_results']:
                             data['steps'] = self.prepare_result_steps(result['custom_step_results'], mappings.result_statuses)


### PR DESCRIPTION
Now all tag values from all projects will be added to the custom field when it is created.
When assigning a tag to a test case, the project and the tag value specific to that project will be taken into account.

This pull request includes several changes to the custom field handling and validation logic in the `cases.py` and `qase.py` files. The most important changes focus on improving the validation and preparation of custom field data, as well as updating the handling of author IDs in the results.

### Improvements to custom field validation:

* [`src/entities/cases.py`](diffhunk://#diff-e3e0e8b1289d7ad9161b51e428756966e0f2c88c969529756ea07fe0d8596e13L199-R212): Updated `_validate_custom_field_values` method to handle project-specific configurations and validate custom field values accordingly.
* [`src/entities/cases.py`](diffhunk://#diff-e3e0e8b1289d7ad9161b51e428756966e0f2c88c969529756ea07fe0d8596e13L208-R224): Enhanced the validation logic to map Qase values correctly when filtering custom field values.

### Custom field data preparation:

* [`src/service/qase.py`](diffhunk://#diff-2cd72fc23fedad151862c80528c0bfb1f4fb4252647059b129bc3da764133d0bL162-R180): Modified `prepare_custom_field_data` method to aggregate and assign unique IDs to custom field values, ensuring no duplicate values.

### Handling of author IDs in results:

* [`src/service/qase.py`](diffhunk://#diff-2cd72fc23fedad151862c80528c0bfb1f4fb4252647059b129bc3da764133d0bL339-R349): Commented out the logic for setting the `author_id` in the `send_bulk_results` method, as it is currently not required.